### PR TITLE
fix a [-Werror=uninitialized] problem

### DIFF
--- a/svo_common/src/frame.cpp
+++ b/svo_common/src/frame.cpp
@@ -31,7 +31,7 @@ Frame::Frame(
     size_t n_pyr_levels)
   : id_(frame_counter_++) // TEMPORARY
   , cam_(cam)
-  , key_pts_(5, std::make_pair(-1, BearingVector()))
+  , key_pts_(5, std::make_pair(-1, BearingVector::Zero()))
   , timestamp_(timestamp_ns)
 {
   initFrame(img, n_pyr_levels);
@@ -45,7 +45,7 @@ Frame::Frame(
   : id_(id)
   , cam_(cam)
   , T_f_w_(T_world_cam.inverse())
-  , key_pts_(5, std::make_pair(-1, BearingVector()))
+  , key_pts_(5, std::make_pair(-1, BearingVector::Zero()))
   , timestamp_(timestamp_ns)
 {}
 


### PR DESCRIPTION
Hi, I encountered a [-Werror=uninitialized] compilation problem when compiling svo_common/frame.cpp
```
------------------------------------------------------------------------------------------------
Profile:                     default
Extending:        [explicit] /opt/ros/noetic
Workspace:                   /home/llm/ROS/learning/SVO-Pro
------------------------------------------------------------------------------------------------
Build Space:        [exists] /home/llm/ROS/learning/SVO-Pro/build
Devel Space:        [exists] /home/llm/ROS/learning/SVO-Pro/devel
Install Space:      [unused] /home/llm/ROS/learning/SVO-Pro/install
Log Space:          [exists] /home/llm/ROS/learning/SVO-Pro/logs
Source Space:       [exists] /home/llm/ROS/learning/SVO-Pro/src
DESTDIR:            [unused] None
------------------------------------------------------------------------------------------------
Devel Space Layout:          linked
Install Space Layout:        None
------------------------------------------------------------------------------------------------
Additional CMake Args:       -DCMAKE_BUILD_TYPE=Release -DEIGEN3_INCLUDE_DIR=/usr/include/eigen3
Additional Make Args:        None
Additional catkin Make Args: None
Internal Make Job Server:    True
Cache Job Environments:      False
------------------------------------------------------------------------------------------------
Whitelisted Packages:        None
Blacklisted Packages:        None
------------------------------------------------------------------------------------------------
Workspace configuration appears valid.
------------------------------------------------------------------------------------------------
[build] Found '36' packages in 0.0 seconds.                                                                                                    
[build] Package table is up to date.                                                                                                           
Starting  >>> catkin_simple                                                                                                                    
Starting  >>> gtsam                                                                                                                            
Starting  >>> rqt_svo                                                                                                                          
Starting  >>> svo_msgs                                                                                                                         
Starting  >>> vikit_py                                                                                                                         
Finished  <<< vikit_py                                     [ 0.2 seconds ]                                                                     
Finished  <<< svo_msgs                                     [ 0.3 seconds ]                                                                     
Finished  <<< catkin_simple                                [ 0.2 seconds ]                                                                     
Starting  >>> cmake_external_project_catkin                                                                                                    
Starting  >>> eigen_catkin                                                                                                                     
Starting  >>> fast                                                                                                                             
Starting  >>> gflags_catkin                                                                                                                    
Starting  >>> rpg_trajectory_evaluation                                                                                                        
Starting  >>> svo_cmake                                                                                                                        
Finished  <<< rqt_svo                                      [ 0.1 seconds ]                                                                     
Finished  <<< svo_cmake                                    [ 0.1 seconds ]                                                                     
Finished  <<< fast                                         [ 0.2 seconds ]                                                                     
Finished  <<< gflags_catkin                                [ 0.2 seconds ]                                                                     
Starting  >>> glog_catkin                                                                                                                      
Finished  <<< rpg_trajectory_evaluation                    [ 0.1 seconds ]                                                                     
Finished  <<< eigen_catkin                                 [ 0.2 seconds ]                                                                     
Starting  >>> opengv                                                                                                                           
Finished  <<< cmake_external_project_catkin                [ 0.2 seconds ]                                                                     
Starting  >>> dbow2_catkin                                                                                                                     
Finished  <<< glog_catkin                                  [ 0.2 seconds ]                                                                     
Starting  >>> ceres_catkin                                                                                                                     
Starting  >>> eigen_checks                                                                                                                     
Starting  >>> vikit_solver                                                                                                                     
Finished  <<< ceres_catkin                                 [ 0.2 seconds ]                                                                     
Finished  <<< vikit_solver                                 [ 0.2 seconds ]                                                                     
Finished  <<< opengv                                       [ 0.5 seconds ]                                                                     
Finished  <<< eigen_checks                                 [ 0.2 seconds ]                                                                     
Starting  >>> minkindr                                                                                                                      
Finished  <<< dbow2_catkin                                 [ 1.7 seconds ]                                                                     
Finished  <<< gtsam                                        [ 3.2 seconds ]                                                                     
Finished  <<< minkindr                                     [ 0.1 seconds ]                                                                     
Starting  >>> minkindr_conversions                                                                                                             
Starting  >>> rpg_common                                                                                                                       
Starting  >>> vikit_common                                                                                                                     
Finished  <<< minkindr_conversions                         [ 0.1 seconds ]                                                                     
Finished  <<< rpg_common                                   [ 0.2 seconds ]                                                            
Finished  <<< vikit_common                                 [ 10.3 seconds ]                                                                    
Starting  >>> vikit_cameras                                                                                                                    
Starting  >>> vikit_ros                                                                                  
Finished  <<< vikit_ros                                    [ 10.8 seconds ]                                                                    
Finished  <<< vikit_cameras                                [ 10.7 seconds ]                                                                    
Starting  >>> svo_common                                                                                                                       
_______________________________________________________________________________________________________________________________________________
Errors     << svo_common:make /home/llm/ROS/learning/SVO-Pro/logs/svo_common/build.make.005.log                                                
In file included from /usr/include/eigen3/Eigen/Core:455,
                 from /home/llm/ROS/learning/SVO-Pro/src/rpg_svo_pro_open/vikit/vikit_common/include/vikit/math_utils.h:6,
                 from /home/llm/ROS/learning/SVO-Pro/src/rpg_svo_pro_open/svo_common/include/svo/common/frame.h:14,
                 from /home/llm/ROS/learning/SVO-Pro/src/rpg_svo_pro_open/svo_common/src/frame.cpp:9:
/usr/include/eigen3/Eigen/src/Core/DenseStorage.h: In constructor ‘svo::Frame::Frame(const CameraPtr&, const cv::Mat&, int64_t, svo::size_t)’:
/usr/include/eigen3/Eigen/src/Core/DenseStorage.h:194:66: error: ‘<anonymous>.Eigen::DenseStorage<double, 3, 3, 1, 0>::m_data’ is used uninitialized in this function [-Werror=uninitialized]
  194 |     DenseStorage(const DenseStorage& other) : m_data(other.m_data) {
      |                                                                  ^
cc1plus: all warnings being treated as errors
make[2]: *** [CMakeFiles/svo_common.dir/build.make:63：CMakeFiles/svo_common.dir/src/frame.cpp.o] 错误 1
make[2]: *** 正在等待未完成的任务....
make[1]: *** [CMakeFiles/Makefile2:425：CMakeFiles/svo_common.dir/all] 错误 2
make: *** [Makefile:141：all] 错误 2
cd /home/llm/ROS/learning/SVO-Pro/build/svo_common; catkin build --get-env svo_common | catkin env -si  /usr/bin/make --jobserver-auth=3,4; cd -

...............................................................................................................................................
Failed     << svo_common:make                              [ Exited with code 2 ]                                                              
Failed    <<< svo_common                                   [ 21.4 seconds ]                                                                    
Abandoned <<< svo_pgo                                      [ Unrelated job failed ]                                                            
Abandoned <<< svo_online_loopclosing                       [ Unrelated job failed ]                                                            
Abandoned <<< svo_vio_common                               [ Unrelated job failed ]                                                            
Abandoned <<< svo_global_map                               [ Unrelated job failed ]                                                            
Abandoned <<< svo_test_utils                               [ Unrelated job failed ]                                                            
Abandoned <<< svo_direct                                   [ Unrelated job failed ]                                                            
Abandoned <<< svo_img_align                                [ Unrelated job failed ]                                                            
Abandoned <<< svo_tracker                                  [ Unrelated job failed ]                                                            
Abandoned <<< svo                                          [ Unrelated job failed ]                                                            
Abandoned <<< svo_ceres_backend                            [ Unrelated job failed ]                                                            
Abandoned <<< svo_ros                                      [ Unrelated job failed ]                                                            
Abandoned <<< svo_benchmarking                             [ Unrelated job failed ]                                                            
[build] Summary: 23 of 36 packages succeeded.                                                                                                  
[build]   Ignored:   None.                                                                                                                     
[build]   Warnings:  4 packages succeeded with warnings.                                                                                       
[build]   Abandoned: 12 packages were abandoned.                                                                                               
[build]   Failed:    1 packages failed.                                                                                                        
[build] Runtime: 46.8 seconds total.
```

I fixed this problem by modifing the "Frame" class constructors.

```
Frame::Frame(
    const CameraPtr& cam,
    const cv::Mat& img,
    const int64_t timestamp_ns,
    size_t n_pyr_levels)
  : id_(frame_counter_++) // TEMPORARY
  , cam_(cam)
  , key_pts_(5, std::make_pair(-1, BearingVector::Zero()))
  , timestamp_(timestamp_ns)
{
  initFrame(img, n_pyr_levels);
}

Frame::Frame(
    const int id,
    const int64_t timestamp_ns,
    const CameraPtr& cam,
    const Transformation& T_world_cam)
  : id_(id)
  , cam_(cam)
  , T_f_w_(T_world_cam.inverse())
  , key_pts_(5, std::make_pair(-1, BearingVector::Zero()))
  , timestamp_(timestamp_ns)
{}
```

please check if these modifications is right.